### PR TITLE
Add generator to install advanced features

### DIFF
--- a/lib/generators/awesome_rails_console/install/USAGE
+++ b/lib/generators/awesome_rails_console/install/USAGE
@@ -1,0 +1,5 @@
+Description:
+    Install hirb, pry-byebug, pry-stack_explorer to make your rails console even more awesome
+
+Example:
+    rails generate awesome_rails_console:install

--- a/lib/generators/awesome_rails_console/install/install_generator.rb
+++ b/lib/generators/awesome_rails_console/install/install_generator.rb
@@ -1,0 +1,34 @@
+require 'rails/generators/base'
+
+class AwesomeRailsConsole::InstallGenerator < Rails::Generators::Base
+  source_root File.expand_path('../templates', __FILE__)
+
+  def update_gemfile
+    gem_group :development, :test do
+      gem 'hirb'
+      gem 'hirb-unicode'
+      gem 'pry-byebug'
+      gem 'pry-stack_explorer'
+    end
+
+    inject_into_file 'Gemfile', indication, before: gem_group_declaration
+  end
+
+  def write_to_pryrc_file
+    copy_file '.pryrc', '.pryrc'
+  end
+
+  private
+
+  def indication
+     "# Please clean up duplicated gems if any.\n"\
+       "# Feel free to remove gems that you don't want to use or "\
+       "if they conflict with other gem dependencies. "\
+       "(you might need to update .pryrc also)\n"
+  end
+
+  def gem_group_declaration
+    "group :development, :test do\n"\
+      "  gem 'hirb'\n"
+  end
+end

--- a/lib/generators/awesome_rails_console/install/templates/.pryrc
+++ b/lib/generators/awesome_rails_console/install/templates/.pryrc
@@ -1,0 +1,4 @@
+if Rails.env.development? || Rails.env.test?
+  # This introduces the `table` statement
+  extend Hirb::Console
+end


### PR DESCRIPTION
## Why is this change necessary?
- hire, pry-byebug, pry-stack_explorer were removed by commit
  32b67c4d4bcbc18faf5c80b7208aaa1442e0732b. But they are useful. Should
  let user easy to start using them.
## How does it address the issue?
- Build a rails generator to insert them into `Gemfile` with `.pryrc`
  to configure `hirb`.
## What side effects does this change have?
- Nothing I can think of.
## How it was tested?
- Manually bundle in a test project with `path` option.
