### PR TITLE
Use hirb-unicode-steakknife instead

### DIFF
--- a/lib/generators/awesome_rails_console/install/install_generator.rb
+++ b/lib/generators/awesome_rails_console/install/install_generator.rb
@@ -6,7 +6,7 @@ class AwesomeRailsConsole::InstallGenerator < Rails::Generators::Base
   def update_gemfile
     gem_group :development, :test do
       gem 'hirb'
-      gem 'hirb-unicode'
+      gem 'hirb-unicode-steakknife'
       gem 'pry-byebug'
       gem 'pry-stack_explorer'
     end


### PR DESCRIPTION
fixes #6 

## Why is this change necessary?

- hirb-unicode is not maintained and breaks dependancy for newer
projects.

## How does it address the issue?

- Use steakknife's forked version.

## How it was tested?

- [x] Manually install to a sample project