### PR TITLE
Pry 0.13.0 compatibility

### DIFF
--- a/lib/awesome_rails_console.rb
+++ b/lib/awesome_rails_console.rb
@@ -1,2 +1,5 @@
 require "awesome_rails_console/version"
-require "awesome_rails_console/railtie" if defined?(Rails)
+if defined?(Rails)
+  require "awesome_rails_console/prompts"
+  require "awesome_rails_console/railtie"
+end

--- a/lib/awesome_rails_console/prompts.rb
+++ b/lib/awesome_rails_console/prompts.rb
@@ -14,7 +14,6 @@ module AwesomeRailsConsole
 
     # Define a custom prompt using pre pry-0.13.0 syntax
     def self.pre_pry_13_prompt(old_prompt)
-      puts "pre"
       [
         proc { |*a| "#{Rails.env.classify} #{old_prompt.first.call(*a)}"  },
         proc { |*a| "#{Rails.env.classify} #{old_prompt.second.call(*a)}" }
@@ -24,7 +23,6 @@ module AwesomeRailsConsole
     # Pry 0.13.0 introduces new syntax for registering a prompt.
     # https://github.com/pry/pry/wiki/Customization-and-configuration#Config_prompt
     def self.post_pry_13_prompt(old_prompt)
-      puts "post"
       Pry::Prompt.new(
         :awesome_rails_console, # name
         "awesome_rails_console default prompt", # description

--- a/lib/awesome_rails_console/prompts.rb
+++ b/lib/awesome_rails_console/prompts.rb
@@ -1,0 +1,42 @@
+require "pry-rails"
+
+module AwesomeRailsConsole
+  module Prompts
+    def self.choose_prompt_for_pry_version
+      old_prompt = Pry.config.prompt
+
+      Pry.config.prompt = if Pry::VERSION && (Gem::Version.new(Pry::VERSION) >= Gem::Version.new('0.13.0'))
+        post_pry_13_prompt(old_prompt)
+      else
+        pre_pry_13_prompt(old_prompt)
+      end
+    end
+
+    # Define a custom prompt using pre pry-0.13.0 syntax
+    def self.pre_pry_13_prompt(old_prompt)
+      puts "pre"
+      [
+        proc { |*a| "#{Rails.env.classify} #{old_prompt.first.call(*a)}"  },
+        proc { |*a| "#{Rails.env.classify} #{old_prompt.second.call(*a)}" }
+      ]
+    end
+
+    # Pry 0.13.0 introduces new syntax for registering a prompt.
+    # https://github.com/pry/pry/wiki/Customization-and-configuration#Config_prompt
+    def self.post_pry_13_prompt(old_prompt)
+      puts "post"
+      Pry::Prompt.new(
+        :awesome_rails_console, # name
+        "awesome_rails_console default prompt", # description
+        [
+          proc { |*a| # "main" prompt
+            "#{Rails.env.classify} #{old_prompt.wait_proc.call(*a)}"
+          },
+          proc { |*a| # "wait" prompt (multiline input continuation)
+            "#{Rails.env.classify} #{old_prompt.incomplete_proc.call(*a)}"
+          }
+        ]
+      )
+    end
+  end
+end

--- a/lib/awesome_rails_console/railtie.rb
+++ b/lib/awesome_rails_console/railtie.rb
@@ -33,10 +33,36 @@ module AwesomeRailsConsole
     def show_rails_env_name_before_prompt
       old_prompt = Pry.config.prompt
 
-      Pry.config.prompt = [
+      Pry.config.prompt = if Pry::VERSION && (Gem::Version.new(Pry::VERSION) >= Gem::Version.new('0.13.0'))
+        post_pry_13_prompt(old_prompt)
+      else
+        pre_pry_13_prompt(old_prompt)
+      end
+    end
+
+    # Define a custom prompt using pre pry-0.13.0 syntax
+    def pre_pry_13_prompt(old_prompt)
+      [
         proc { |*a| "#{Rails.env.classify} #{old_prompt.first.call(*a)}"  },
         proc { |*a| "#{Rails.env.classify} #{old_prompt.second.call(*a)}" }
       ]
+    end
+
+    # Pry 0.13.0 introduces new syntax for registering a prompt.
+    # https://github.com/pry/pry/wiki/Customization-and-configuration#Config_prompt
+    def post_pry_13_prompt(old_prompt)
+      Pry::Prompt.new(
+        :awesome_rails_console, # name
+        "awesome_rails_console default prompt", # description
+        [
+          proc { |*a| # "main" prompt
+            "#{Rails.env.classify} #{old_prompt.wait_proc.call(*a)}"
+          },
+          proc { |*a| # "wait" prompt (multiline input continuation)
+            "#{Rails.env.classify} #{old_prompt.incomplete_proc.call(*a)}"
+          }
+        ]
+      )
     end
   end
 end

--- a/lib/awesome_rails_console/railtie.rb
+++ b/lib/awesome_rails_console/railtie.rb
@@ -31,38 +31,7 @@ module AwesomeRailsConsole
     end
 
     def show_rails_env_name_before_prompt
-      old_prompt = Pry.config.prompt
-
-      Pry.config.prompt = if Pry::VERSION && (Gem::Version.new(Pry::VERSION) >= Gem::Version.new('0.13.0'))
-        post_pry_13_prompt(old_prompt)
-      else
-        pre_pry_13_prompt(old_prompt)
-      end
-    end
-
-    # Define a custom prompt using pre pry-0.13.0 syntax
-    def pre_pry_13_prompt(old_prompt)
-      [
-        proc { |*a| "#{Rails.env.classify} #{old_prompt.first.call(*a)}"  },
-        proc { |*a| "#{Rails.env.classify} #{old_prompt.second.call(*a)}" }
-      ]
-    end
-
-    # Pry 0.13.0 introduces new syntax for registering a prompt.
-    # https://github.com/pry/pry/wiki/Customization-and-configuration#Config_prompt
-    def post_pry_13_prompt(old_prompt)
-      Pry::Prompt.new(
-        :awesome_rails_console, # name
-        "awesome_rails_console default prompt", # description
-        [
-          proc { |*a| # "main" prompt
-            "#{Rails.env.classify} #{old_prompt.wait_proc.call(*a)}"
-          },
-          proc { |*a| # "wait" prompt (multiline input continuation)
-            "#{Rails.env.classify} #{old_prompt.incomplete_proc.call(*a)}"
-          }
-        ]
-      )
+      Prompts.choose_prompt_for_pry_version
     end
   end
 end

--- a/spec/awesome_rails_console/prompts_spec.rb
+++ b/spec/awesome_rails_console/prompts_spec.rb
@@ -3,9 +3,9 @@ require 'spec_helper'
 require 'awesome_rails_console/prompts'
 
 describe AwesomeRailsConsole::Prompts do
-  describe '.choose_prompt_for_pry_version' do
-    let(:old_prompt) { double('Pry.config.prompt') }
+  let(:old_prompt) { double('Pry.config.prompt') }
 
+  describe '.choose_prompt_for_pry_version' do
     before do
       expect(Pry.config).to receive(:prompt).and_return(old_prompt)
     end
@@ -30,6 +30,21 @@ describe AwesomeRailsConsole::Prompts do
         expect(described_class).to receive(:post_pry_13_prompt).with(old_prompt)
         described_class.choose_prompt_for_pry_version
       end
+    end
+  end
+
+  describe '.pre_pry_13_prompt' do
+    subject { described_class.pre_pry_13_prompt(old_prompt) }
+
+    it 'returns array of procs' do
+      expect(subject).to be_a_kind_of(Array)
+      expect(subject.all?{|p| p.is_a?(Proc)}).to be_truthy
+    end
+  end
+
+  describe '.post_pry_13_prompt' do
+    it 'returns instance of Pry::Prompt' do
+      expect(described_class.post_pry_13_prompt(old_prompt)).to be_a_kind_of(Pry::Prompt)
     end
   end
 end

--- a/spec/awesome_rails_console/prompts_spec.rb
+++ b/spec/awesome_rails_console/prompts_spec.rb
@@ -3,31 +3,33 @@ require 'spec_helper'
 require 'awesome_rails_console/prompts'
 
 describe AwesomeRailsConsole::Prompts do
-  let(:old_prompt) { double('Pry.config.prompt') }
+  describe '.choose_prompt_for_pry_version' do
+    let(:old_prompt) { double('Pry.config.prompt') }
 
-  before do
-    expect(Pry.config).to receive(:prompt).and_return(old_prompt)
-  end
-
-  context 'pry version < 0.13.0' do
     before do
-      stub_const("Pry::VERSION", '0.12.2')
+      expect(Pry.config).to receive(:prompt).and_return(old_prompt)
     end
 
-    it 'uses pre-0.13.0 prompt' do
-      expect(described_class).to receive(:pre_pry_13_prompt).with(old_prompt)
-      described_class.choose_prompt_for_pry_version
-    end
-  end
+    context 'pry version < 0.13.0' do
+      before do
+        stub_const("Pry::VERSION", '0.12.2')
+      end
 
-  context 'pry version >= 0.13.0' do
-    before do
-      stub_const("Pry::VERSION", '0.13.1')
+      it 'uses pre-0.13.0 prompt' do
+        expect(described_class).to receive(:pre_pry_13_prompt).with(old_prompt)
+        described_class.choose_prompt_for_pry_version
+      end
     end
 
-    it 'uses post-0.13.0 prompt' do
-      expect(described_class).to receive(:post_pry_13_prompt).with(old_prompt)
-      described_class.choose_prompt_for_pry_version
+    context 'pry version >= 0.13.0' do
+      before do
+        stub_const("Pry::VERSION", '0.13.1')
+      end
+
+      it 'uses post-0.13.0 prompt' do
+        expect(described_class).to receive(:post_pry_13_prompt).with(old_prompt)
+        described_class.choose_prompt_for_pry_version
+      end
     end
   end
 end

--- a/spec/awesome_rails_console/prompts_spec.rb
+++ b/spec/awesome_rails_console/prompts_spec.rb
@@ -1,0 +1,33 @@
+require 'spec_helper'
+
+require 'awesome_rails_console/prompts'
+
+describe AwesomeRailsConsole::Prompts do
+  let(:old_prompt) { double('Pry.config.prompt') }
+
+  before do
+    expect(Pry.config).to receive(:prompt).and_return(old_prompt)
+  end
+
+  context 'pry version < 0.13.0' do
+    before do
+      stub_const("Pry::VERSION", '0.12.2')
+    end
+
+    it 'uses pre-0.13.0 prompt' do
+      expect(described_class).to receive(:pre_pry_13_prompt).with(old_prompt)
+      described_class.choose_prompt_for_pry_version
+    end
+  end
+
+  context 'pry version >= 0.13.0' do
+    before do
+      stub_const("Pry::VERSION", '0.13.1')
+    end
+
+    it 'uses post-0.13.0 prompt' do
+      expect(described_class).to receive(:post_pry_13_prompt).with(old_prompt)
+      described_class.choose_prompt_for_pry_version
+    end
+  end
+end


### PR DESCRIPTION
Adds compatibility for the new prompt syntax in Pry 0.13.0+, to address #11 .

The prompt logic is moved to a separate module (`prompts.rb`) so that the pry version detection can be tested with rspec without having to build a rails test_app around them.

Testing this interactively is tricky; you'll need to add something like this to the `.gemspec`:

```ruby
spec.add_dependency "pry", ">= 0.13.0"
  # spec.add_dependency "pry", "< 0.13.0"
```

..and (un)comment the appropriate line, and then `bundle update` after the change inside the app that is using this gem.

